### PR TITLE
Adds interface_attach config option in tempest

### DIFF
--- a/devstack_vm/bin/excluded-tests.txt
+++ b/devstack_vm/bin/excluded-tests.txt
@@ -2,10 +2,6 @@
 tempest.api.compute.servers.test_server_rescue.ServerRescueTestJSON.
 tempest.api.compute.servers.test_server_rescue_negative.ServerRescueNegativeTestJSON.
 
-# Hyper-V does not support attaching vNics to a running instance 
-tempest.api.compute.servers.test_attach_interfaces.AttachInterfacesTestJSON.test_create_list_show_delete_interfaces
-tempest.scenario.test_network_basic_ops.TestNetworkBasicOps.test_hotplug_nic
-
 # See Tempest bug: https://bugs.launchpad.net/tempest/+bug/1363986
 tempest.scenario.test_security_groups_basic_ops.TestSecurityGroupsBasicOps
 
@@ -54,7 +50,6 @@ tempest.scenario.test_shelve_instance.TestShelveInstance
 tempest.scenario.test_snapshot_pattern.TestSnapshotPattern
 tempest.scenario.test_server_advanced_ops.TestServerAdvancedOps.test_resize_server_confirm
 #Need investigation - recently enabled in tempest
-tempest.scenario.test_network_basic_ops.TestNetworkBasicOps.test_port_security_macspoofing_port
 tempest.scenario.test_network_basic_ops.TestNetworkBasicOps.test_preserve_preexisting_port
 tempest.scenario.test_network_basic_ops.TestNetworkBasicOps.test_update_instance_port_admin_state
 tempest.scenario.test_network_basic_ops.TestNetworkBasicOps.test_update_router_admin_state

--- a/devstack_vm/devstack/local.sh
+++ b/devstack_vm/devstack/local.sh
@@ -37,6 +37,7 @@ iniset $TEMPEST_CONFIG compute-feature-enabled rdp_console true
 iniset $TEMPEST_CONFIG compute-feature-enabled block_migrate_cinder_iscsi True
 iniset $TEMPEST_CONFIG compute-feature-enabled block_migration_for_live_migration True
 iniset $TEMPEST_CONFIG compute-feature-enabled live_migration True
+iniset $TEMPEST_CONFIG compute-feature-enabled interface_attach False
 
 iniset $TEMPEST_CONFIG scenario img_dir "/home/ubuntu/devstack/files/images/"
 iniset $TEMPEST_CONFIG scenario img_file "cirros-0.3.3-x86_64.vhdx"


### PR DESCRIPTION
The interface_attach config option represents the capability to hotplug
vNICs. vNICs can only be hotplugged on Generation 2 VMs and Windows / Hyper-V
Server 2016.

Sets the config option to False.
Removes redundant tests from the exclude list.
